### PR TITLE
Error handling for youtubedl (clips)

### DIFF
--- a/src/clip-url-fetcher.ts
+++ b/src/clip-url-fetcher.ts
@@ -6,8 +6,12 @@ export async function getClipUrl(clip: Clip): Promise<string> {
     logger.verbose(`Fetching clip URL for: ${clip.title}`);
 
     // Use YoutubeDL to fetch manifest URL
-    const meta = (await youtubedl.getVideoInfo(clip.url)) as YoutubeDlClipDump;
-    logger.verbose(`youtube-dl: ${clip.title} .mp4 file URL: ${meta.url}`);
-
-    return meta.url;
+    try {
+        const meta = (await youtubedl.getVideoInfo(clip.url)) as YoutubeDlClipDump;
+        logger.verbose(`youtube-dl: ${clip.title} .mp4 file URL: ${meta.url}`);
+        return meta.url;
+    } catch (error) {
+        logger.error(`youtube-dl: Failed to retrieve the clip URL for ${clip.title}`);
+        return "";
+    }
 }

--- a/src/clips-downloader.ts
+++ b/src/clips-downloader.ts
@@ -112,16 +112,18 @@ export class ClipsDownloader extends EventEmitter {
         if (!existsSync(appPath(mp4Path))) {
             const url = await getClipUrl(clip);
 
-            fs.writeFileSync(appPath(metaPath), JSON.stringify(clip));
+            if(url) {
+                fs.writeFileSync(appPath(metaPath), JSON.stringify(clip));
 
-            const downloader = new Downloader(url, mp4Path);
+                const downloader = new Downloader(url, mp4Path);
 
-            downloader.on('progress', bytes => {
-                this.speed.data(bytes);
-            });
+                downloader.on('progress', bytes => {
+                    this.speed.data(bytes);
+                });
 
-            logger.verbose(`Downloading clip ${clip.title}`);
-            await downloader.download();
+                logger.verbose(`Downloading clip ${clip.title}`);
+                await downloader.download();
+            }
         } else {
             logger.verbose(`Clip ${clip.title} found at ${appPath(mp4Path)}`);
         }


### PR DESCRIPTION
Added try/catch block to avoid the application breaking when youtubedl fails to retrieve the URL of a clip.

This fixes #29 